### PR TITLE
Add KSign support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The tool includes built-in support for pairing file formats used by:
 - **StikDebug**: RPPairing: `rp_pairing_file.plist`, Lockdown: `pairingFile.plist`.
 - **SparseBox**: `pairingFile.plist`
 - **Feather**: `pairingFile.plist`
+- **Protokolle**: `pairingFile.plist`
 - **Antrag**: `pairingFile.plist`
 - **KSign**: `pairingFile.plist`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A cross-platform GUI application for managing iOS device pairing and wireless de
   - [Feather](https://github.com/khcrysalis/Feather)
   - [Protokolle](https://github.com/khcrysalis/Protokolle)
   - [Antrag](https://github.com/khcrysalis/Antrag)
+  - [KSign](https://github.com/Nyasami/Ksign)
 - **Developer Mode**: Monitor developer mode status
 - **Developer Disk Image Mounting**: Automatically mount required developer images
 
@@ -116,8 +117,8 @@ The tool includes built-in support for pairing file formats used by:
 - **StikDebug**: RPPairing: `rp_pairing_file.plist`, Lockdown: `pairingFile.plist`.
 - **SparseBox**: `pairingFile.plist`
 - **Feather**: `pairingFile.plist`
-- **Protokolle**: `pairingFile.plist`
 - **Antrag**: `pairingFile.plist`
+- **KSign**: `pairingFile.plist`
 
 ## Dependencies
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,7 @@ fn supported_apps_for_mode(mode: PairingMode) -> HashMap<String, String> {
             supported_apps.insert("SparseBox".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("ByeTunes".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("StikDebug".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("Ksign".to_string(), "pairingFile.plist".to_string());
         }
         PairingMode::RemotePairing => {
             supported_apps
@@ -110,6 +111,7 @@ fn supported_apps_for_mode(mode: PairingMode) -> HashMap<String, String> {
             supported_apps.insert("Protokolle".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Antrag".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Feather".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("Ksign".to_string(), "pairingFile.plist".to_string());
         }
     }
     supported_apps


### PR DESCRIPTION
This adds KSign to the list of supported apps for both Lockdown and RPPairing modes, which is necessary for iOS 17.4+ support. Reference KSign issue: https://github.com/Nyasami/Ksign/issues/104.