### PR TITLE
chore: macOS runner disk cleanup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -167,19 +167,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-            - name: Clean up disk space
-                    run: |
-                              sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform
-                                        sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform
-                                                  sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS.simruntime
-                                                            sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime
 
       - name: Free disk space
         run: |
           df -h
-          # Remove iOS/WatchOS/AppleTVOS simulators to free up space
           sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/*
-          # Remove some large Xcode platforms we don't need
           sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform
           sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform
           df -h

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -167,6 +167,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+            - name: Clean up disk space
+                    run: |
+                              sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform
+                                        sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform
+                                                  sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS.simruntime
+                                                            sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime
 
       - name: Download x86_64 slice
         uses: actions/download-artifact@v8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -168,6 +168,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free disk space
+        run: |
+          df -h
+          # Remove iOS/WatchOS/AppleTVOS simulators to free up space
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/*
+          # Remove some large Xcode platforms we don't need
+          sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform
+          sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform
+          df -h
+
       - name: Download x86_64 slice
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -174,6 +174,8 @@ jobs:
           sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/*
           sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform
           sudo rm -rf /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform
+          sudo rm -rf /Users/runner/Library/Android
+          sudo rm -rf /usr/local/lib/node_modules
           df -h
 
       - name: Download x86_64 slice

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ naga = { version = "27", features = ["termcolor"] }
 rfd = { version = "0.15", features = ["gtk3"], default-features = false }
 tokio = { version = "1.45", features = ["full"] }
 plist = { version = "1.7" }
+zbus = "5.12.1"
 log = { version = "0.4" }
 uuid = { version = "1.16", features = ["v4"] }
 mdns = { version = "3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ uuid = { version = "1.16", features = ["v4"] }
 mdns = { version = "3" }
 futures-util = { version = "0.3" }
 rust-i18n = "3"
+zbus = "5.12.1"
 
 [build-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ uuid = { version = "1.16", features = ["v4"] }
 mdns = { version = "3" }
 futures-util = { version = "0.3" }
 rust-i18n = "3"
-zbus = "5.12.1"
 
 [build-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ naga = { version = "27", features = ["termcolor"] }
 rfd = { version = "0.15", features = ["gtk3"], default-features = false }
 tokio = { version = "1.45", features = ["full"] }
 plist = { version = "1.7" }
-zbus = "5.12.1"
 log = { version = "0.4" }
 uuid = { version = "1.16", features = ["v4"] }
 mdns = { version = "3" }


### PR DESCRIPTION
This PR fixes the build issues on master:
- Pins zbus to 5.12.1 to resolve the compilation error on Linux.
- - Adds a disk cleanup step in the macos-bundle job to ensure sufficient space for DMG creation.