### PR TITLE
Add Auto Capture to supported apps

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,10 @@ fn supported_apps_for_mode(mode: PairingMode) -> HashMap<String, String> {
             supported_apps.insert("Antrag".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Feather".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Ksign".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert(
+                "Auto Capture".to_string(),
+                "rpPairingFile.plist".to_string(),
+            );
         }
     }
     supported_apps


### PR DESCRIPTION
Auto Capture 1.2.0 supports RPPairing files. This adds Auto Capture to the list of supported devices for idevice pair.