### PR TITLE
Add alt_irk support and fix DDI downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,32 +1125,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossfire"
-version = "2.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd901251b9b46c1752c85edfee0aee718c03a85a065f4126d32e5d6d419edf48"
-dependencies = [
- "crossbeam-queue",
- "crossbeam-utils",
- "enum_dispatch",
- "futures-core",
- "parking_lot",
-]
 
 [[package]]
 name = "crunchy"
@@ -1512,18 +1490,6 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "enumflags2"
@@ -1926,9 +1892,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2404,7 +2372,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2506,15 +2474,14 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idevice"
-version = "0.1.58"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066aab61e525fdc6181ae32bf88d535a1eae8462e3e190516ec15a863f5926cd"
+checksum = "ab414e99190ac3dcd39587a210c1799ec3f8ef5943d132024108409bfa6976ab"
 dependencies = [
  "aes",
  "async-stream 0.3.6",
  "async_zip",
  "base64 0.22.1",
- "byteorder",
  "cbc",
  "chacha20poly1305",
  "chrono",
@@ -2525,7 +2492,7 @@ dependencies = [
  "idevice-srp",
  "indexmap",
  "jktcp",
- "json",
+ "libc",
  "plist",
  "plist-macro",
  "rand 0.10.1",
@@ -2536,11 +2503,13 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "siphasher",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
  "uuid",
+ "web-time",
  "x25519-dalek",
  "x509-cert",
 ]
@@ -2561,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "idevice_pair"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "eframe",
  "egui",
@@ -2687,15 +2656,17 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jktcp"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b9d88c89c8fe802c7e7c2bf32b0fb85ef53187c30a8f130d41578b4362baa7"
+checksum = "5d8c094fb3ffeaa1c4b94d176c6fd6d615433c9d25e0e5a52f56b96635e4d246"
 dependencies = [
- "crossfire",
  "futures",
+ "getrandom 0.3.4",
  "rand 0.9.4",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -2777,12 +2748,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "khronos-egl"
@@ -5457,6 +5422,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5871,19 +5849,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.13"
 edition = "2024"
 
 [dependencies]
-idevice = { version = "0.1.57", features = [
+idevice = { version = "0.1.61", features = [
   "pair",
   "usbmuxd",
   "installation_proxy",

--- a/build.rs
+++ b/build.rs
@@ -25,22 +25,27 @@ fn main() {
     }
 
     println!("cargo:rerun-if-changed=build.rs");
+    for file in OUTPUT_FILES {
+        println!("cargo:rerun-if-changed={file}");
+    }
 
     // Ensure output directory exists
     if !Path::new(OUTPUT_DIR).exists() {
         fs::create_dir_all(OUTPUT_DIR).expect("Failed to create DDI directory");
     }
 
-    // Check if the file already exists
-    if Path::new(OUTPUT_FILES[0]).exists() {
-        return;
-    }
+    for (url, output_file) in URLS.iter().zip(OUTPUT_FILES.iter()) {
+        if file_exists_with_content(output_file) {
+            continue;
+        }
 
-    // Download the file using reqwest
-    println!("Downloading BuildManifest.plist...");
-    for (i, url) in URLS.iter().enumerate() {
+        println!("Downloading {output_file}...");
         let response = get(*url).expect("Failed to send request");
         let bytes = response.bytes().expect("Failed to read response");
-        fs::write(OUTPUT_FILES[i], &bytes).expect("Failed to write file");
+        fs::write(output_file, &bytes).expect("Failed to write file");
     }
+}
+
+fn file_exists_with_content(path: &str) -> bool {
+    fs::metadata(path).map(|metadata| metadata.len() > 0).unwrap_or(false)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,14 +174,13 @@ async fn generate_remote_pairing_file(
         .await?;
 
     // use it to try and force keychain commitment
-    // iOS has trouble commiting I guess
+    // iOS has trouble committing I guess
     let tunnel_service_stream = adapter.connect(tunnel_service.port).await?;
     let mut remote_xpc = RemoteXpcClient::new(tunnel_service_stream).await?;
     remote_xpc.do_handshake().await?;
     let _ = remote_xpc.recv_root().await;
 
     send_pairing_status(gui_sender, t!("starting_rp"));
-    let mut pairing_file = RpPairingFile::generate(hostname);
     let mut pairing_client = RemotePairingClient::new(remote_xpc, hostname);
     pairing_client
         .connect(&mut pairing_file, || async { "000000".to_string() })

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,13 +45,6 @@ enum PairingMode {
 }
 
 impl PairingMode {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Lockdown => "Lockdown",
-            Self::RemotePairing => "RPPairing",
-        }
-    }
-
     fn default_file_name(self, udid: &str) -> String {
         match self {
             Self::Lockdown => format!("{udid}.plist"),
@@ -175,9 +168,9 @@ async fn generate_remote_pairing_file(
     send_pairing_status(gui_sender, t!("starting_rp"));
     send_pairing_status(gui_sender, t!("trust_device"));
     let mut pairing_file = RpPairingFile::generate(hostname);
-    let mut pairing_client = RemotePairingClient::new(remote_xpc, hostname, &mut pairing_file);
+    let mut pairing_client = RemotePairingClient::new(remote_xpc, hostname);
     pairing_client
-        .connect(async |_| "000000".to_string(), ())
+        .connect(&mut pairing_file, || async { "000000".to_string() })
         .await?;
 
     // use it to try and force keychain commitment
@@ -188,9 +181,10 @@ async fn generate_remote_pairing_file(
     let _ = remote_xpc.recv_root().await;
 
     send_pairing_status(gui_sender, t!("starting_rp"));
-    let mut pairing_client = RemotePairingClient::new(remote_xpc, hostname, &mut pairing_file);
+    let mut pairing_file = RpPairingFile::generate(hostname);
+    let mut pairing_client = RemotePairingClient::new(remote_xpc, hostname);
     pairing_client
-        .connect(async |_| "000000".to_string(), ())
+        .connect(&mut pairing_file, || async { "000000".to_string() })
         .await?;
 
     Ok(pairing_file)
@@ -710,9 +704,9 @@ fn main() {
                         let _ = conn.recv_root().await;
 
                         let hostname = pairing_hostname();
-                        let mut rpc = RemotePairingClient::new(conn, &hostname, &mut pairing_file);
+                        let mut rpc = RemotePairingClient::new(conn, &hostname);
                         let _ = rpc.attempt_pair_verify().await?;
-                        rpc.validate_pairing().await
+                        rpc.validate_pairing(&mut pairing_file).await
                     })
                     .catch_unwind()
                     .await;


### PR DESCRIPTION
- Updated `idevice` from `0.1.57` to `0.1.61`
- Adjusted remote pairing calls for the updated `idevice` API.
- Fixed DDI download caching exiting early when `BuildManifest.plist` existed
- Removed unused `PairingMode::label` method.