### PR TITLE
Updates supported apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A cross-platform GUI application for managing iOS device pairing and wireless de
   - [Protokolle](https://github.com/khcrysalis/Protokolle)
   - [Antrag](https://github.com/khcrysalis/Antrag)
   - [KSign](https://github.com/Nyasami/Ksign)
+  - [EnsWilde](https://github.com/YangJiiii/EnsWilde)
+  - [Reynard Browser](https://github.com/minh-ton/reynard-browser)
+  - [Auto Capture](https://apps.apple.com/us/app/dev-auto-capture/id6755616902)
+  - [StosDebug](https://github.com/stossy11/StosDebug)
 - **Developer Mode**: Monitor developer mode status
 - **Developer Disk Image Mounting**: Automatically mount required developer images
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,24 +93,40 @@ fn supported_apps_for_mode(mode: PairingMode) -> HashMap<String, String> {
                 "SideStore/Documents/ALTPairingFile.mobiledevicepairing".to_string(),
             );
             supported_apps.insert("SparseBox".to_string(), "pairingFile.plist".to_string());
-            supported_apps.insert("ByeTunes".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("StikDebug".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("EnsWilde".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("StikDebug (Sideloaded)".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("Protokolle".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("Antrag".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("Feather".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("StikStore".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Ksign".to_string(), "pairingFile.plist".to_string());
+
         }
         PairingMode::RemotePairing => {
             supported_apps.insert(
+                "SideStore".to_string(),
+                "ALTPairingFile.mobiledevicepairing".to_string(),
+            );
+            supported_apps.insert(
+                "LiveContainer".to_string(),
+                "SideStore/Documents/ALTPairingFile.mobiledevicepairing".to_string(),
+            );
+            supported_apps.insert(
                 "StikDebug (Sideloaded)".to_string(),
                 RP_PAIRING_FILE_NAME.to_string(),
+            );
+            supported_apps.insert(
+                "Auto Capture".to_string(),
+                "rpPairingFile.plist".to_string(),
             );
             supported_apps.insert("StosDebug".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Protokolle".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Antrag".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Feather".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("StosDebug".to_string(), "pairingFile.plist".to_string());
+            supported_apps.insert("Reynard".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Ksign".to_string(), "pairingFile.plist".to_string());
-            supported_apps.insert(
-                "Auto Capture".to_string(),
-                "rpPairingFile.plist".to_string(),
-            );
         }
     }
     supported_apps

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,6 @@ fn supported_apps_for_mode(mode: PairingMode) -> HashMap<String, String> {
             supported_apps.insert("Protokolle".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Antrag".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Feather".to_string(), "pairingFile.plist".to_string());
-            supported_apps.insert("StosDebug".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Reynard".to_string(), "pairingFile.plist".to_string());
             supported_apps.insert("Ksign".to_string(), "pairingFile.plist".to_string());
         }


### PR DESCRIPTION
- Readd lockdown support for some legacy application versions
- Add EnsWilde to lockdown pairing
- Add Reynard Browser pairing
- Add RPPairing for SideStore/SideStore+LiveContainer
- Removes ByeTunes because piracy
Will add AltStore once I find the file path
Squash when merging pls